### PR TITLE
🐛 LdapEntry display of values are too large

### DIFF
--- a/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
+++ b/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
@@ -113,7 +113,7 @@ export default {
             this.$set(this.attributesHiddenState, key, true);
           });
           this.attributes = result.attributes;
-        })
+        });
     } else {
       this.attributes = null;
     }

--- a/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
+++ b/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
@@ -46,13 +46,20 @@
                     class="mb-1"
                   >
                     <template>
+                      <b-button
+                        v-if="!!value && value.length > shortenSize"
+                        size="is-small"
+                        :icon-left="!!attributesHiddenState[key] ? 'eye-slash' : 'eye'"
+                        class="is-cursor-pointer"
+                        @click="displayValueHidden(key)"
+                      >
+                        Show
+                      </b-button>
                       <span
                         :key="`spanEntryValue:${value}`"
                         class="column is-full is-centered p-0 has-text-centered break-word"
-                        :class="{'hidden-overflow': attributesHiddenState[key]}"
-                        @click="displayValueHidden(key)"
                       >
-                        {{ value }}
+                        {{ value | shorten(attributesHiddenState[key] ? shortenSize : -1) }}
                       </span>
                     </template>
                   </div>
@@ -68,10 +75,16 @@
 
 
 <script lang="ts">
+import { truncate } from "../../../../common/helpers";
 import { ILdapAttributes, ILdapEntry } from "../../interfaces/entry";
 
 export default {
   name: "AppLdapEntry",
+  filters: {
+    shorten(value: string | null, length: number = 20) {
+      return length > 0 ? truncate(value, length) : value;
+    },
+  },
   props: {
     dn: {
       type: String,
@@ -80,6 +93,7 @@ export default {
   },
   data() {
     return {
+      shortenSize: 20,
       attributes: null as ILdapAttributes,
       attributesHiddenState: {} as ILdapAttributes,
     };
@@ -89,10 +103,10 @@ export default {
       await this.$store
         .dispatch("ldapEntry/get", this.dn)
         .then((result: ILdapEntry) => {
-          this.attributes = result.attributes;
-          Object.keys(this.attributes).forEach(key => {
+          Object.keys(result.attributes).forEach(key => {
             this.$set(this.attributesHiddenState, key, true);
           });
+          this.attributes = result.attributes;
         })
     } else {
       this.attributes = null;
@@ -135,15 +149,11 @@ export default {
   border-bottom: 1px solid $grey-darker;
 }
 
-.break-word {
+.icon.is-cursor-pointer {
   cursor: pointer;
-  word-wrap: break-word;
 }
 
-.hidden-overflow {
-  cursor: pointer;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.break-word {
+  word-wrap: break-word;
 }
 </style>

--- a/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
+++ b/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
@@ -25,7 +25,7 @@
               :key="`divElemente:${key}`"
               class="columns ml-4 bb-1"
             >
-              <div class="column is-6">
+              <div class="column is-5">
                 <div class="columns mb-0 is-mobile is-centered">
                   <div class="column is-7 has-text-centered">
                     <span
@@ -39,16 +39,18 @@
                 </div>
               </div>
 
-              <div class="column mt-0 mb-2 pt-0">
+              <div class="column is-7">
                 <template v-for="(value, indexValue) in attribute">
                   <div
                     :key="`divInputValue${indexValue}`"
-                    class="is-flex is-justify-content-center mb-1"
+                    class="mb-1"
                   >
                     <template>
                       <span
                         :key="`spanEntryValue:${value}`"
-                        class="is-centered"
+                        class="column is-full is-centered p-0 has-text-centered break-word"
+                        :class="{'hidden-overflow': attributesHiddenState[key]}"
+                        @click="displayValueHidden(key)"
                       >
                         {{ value }}
                       </span>
@@ -78,7 +80,8 @@ export default {
   },
   data() {
     return {
-      attributes: null as ILdapAttributes
+      attributes: null as ILdapAttributes,
+      attributesHiddenState: {} as ILdapAttributes,
     };
   },
   async created() {
@@ -87,7 +90,10 @@ export default {
         .dispatch("ldapEntry/get", this.dn)
         .then((result: ILdapEntry) => {
           this.attributes = result.attributes;
-        });
+          Object.keys(this.attributes).forEach(key => {
+            this.$set(this.attributesHiddenState, key, true);
+          });
+        })
     } else {
       this.attributes = null;
     }
@@ -115,6 +121,9 @@ export default {
 
       return title;
     },
+    displayValueHidden(key: string): void {
+      this.attributesHiddenState[key] = !this.attributesHiddenState[key]; 
+    },
   }
 };
 </script>
@@ -124,5 +133,17 @@ export default {
 
 .bb-1 {
   border-bottom: 1px solid $grey-darker;
+}
+
+.break-word {
+  cursor: pointer;
+  word-wrap: break-word;
+}
+
+.hidden-overflow {
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 </style>

--- a/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
+++ b/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
@@ -44,11 +44,11 @@
                   class="column p-0 mb-1 is-flex is-justify-content-center"
                 >
                   <b-button
-                    v-if="attribute.some(displayShowButton)"
+                    v-if="attribute.some(isShowButtonDisplayed)"
                     size="is-small"
-                    :icon-left="!!attributesHiddenState[key] ? 'eye-slash' : 'eye'"
+                    :icon-left="isValueFullDisplayed(key) ? 'eye-slash' : 'eye'"
                     class="is-cursor-pointer"
-                    @click="displayValueHidden(key)"
+                    @click="toggleValueFullDisplay(key)"
                   >
                     {{ $t("common.view") }}
                   </b-button>
@@ -62,7 +62,7 @@
                       :key="`spanEntryValue:${value}`"
                       class="column is-full is-centered p-0 has-text-centered break-word"
                     >
-                      {{ value | shorten(attributesHiddenState[key] ? shortenSize : -1) }}
+                      {{ value | shorten(isValueFullDisplayed(key) ? shortenSize : -1) }}
                     </span>
                   </div>
                 </template>
@@ -141,10 +141,13 @@ export default {
 
       return title;
     },
-    displayShowButton(value: string): boolean {
+    isShowButtonDisplayed(value: string): boolean {
       return value.length > this.shortenSize;
     },
-    displayValueHidden(key: string): void {
+    isValueFullDisplayed(key: string): boolean {
+      return this.attributesHiddenState[key] ?? false;
+    },
+    toggleValueFullDisplay(key: string): void {
       this.attributesHiddenState[key] = !this.attributesHiddenState[key]; 
     },
   }

--- a/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
+++ b/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
@@ -40,32 +40,30 @@
               </div>
 
               <div class="column is-7">
+                <div
+                  class="column p-0 mb-1 is-flex is-justify-content-center"
+                >
+                  <b-button
+                    v-if="attribute.some(displayShowButton)"
+                    size="is-small"
+                    :icon-left="!!attributesHiddenState[key] ? 'eye-slash' : 'eye'"
+                    class="is-cursor-pointer"
+                    @click="displayValueHidden(key)"
+                  >
+                    {{ $t("common.view") }}
+                  </b-button>
+                </div>
                 <template v-for="(value, indexValue) in attribute">
                   <div
-                    :key="`divInputValue${indexValue}`"
+                    :key="`divValue${indexValue}`"
                     class="mb-1"
                   >
-                    <div class="columns mb-0 is-mobile">
-                      <div class="column is-9">
-                        <span
-                          :key="`spanEntryValue:${value}`"
-                          class="column is-full is-centered p-0 has-text-centered break-word"
-                        >
-                          {{ value | shorten(attributesHiddenState[key] ? shortenSize : -1) }}
-                        </span>
-                      </div>
-                      <div class="column is-3 p-0 is-flex is-justify-content-center">
-                        <b-button
-                          v-if="!!value && value.length > shortenSize"
-                          size="is-small"
-                          :icon-left="!!attributesHiddenState[key] ? 'eye-slash' : 'eye'"
-                          class="is-cursor-pointer"
-                          @click="displayValueHidden(key)"
-                        >
-                          {{ $t("common.view") }}
-                        </b-button>
-                      </div>
-                    </div>
+                    <span
+                      :key="`spanEntryValue:${value}`"
+                      class="column is-full is-centered p-0 has-text-centered break-word"
+                    >
+                      {{ value | shorten(attributesHiddenState[key] ? shortenSize : -1) }}
+                    </span>
                   </div>
                 </template>
               </div>
@@ -101,7 +99,7 @@ export default {
   },
   data() {
     return {
-      shortenSize: 15,
+      shortenSize: 26,
       attributes: null as ILdapAttributes,
       attributesHiddenState: {} as ILdapAttributesHiddenState,
     };
@@ -142,6 +140,13 @@ export default {
       }
 
       return title;
+    },
+    displayShowButton(key: string): boolean {
+      if (key.length > this.shortenSize) {
+        return true;
+      } else {
+        return false;
+      }
     },
     displayValueHidden(key: string): void {
       this.attributesHiddenState[key] = !this.attributesHiddenState[key]; 

--- a/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
+++ b/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
@@ -45,23 +45,27 @@
                     :key="`divInputValue${indexValue}`"
                     class="mb-1"
                   >
-                    <template>
-                      <b-button
-                        v-if="!!value && value.length > shortenSize"
-                        size="is-small"
-                        :icon-left="!!attributesHiddenState[key] ? 'eye-slash' : 'eye'"
-                        class="is-cursor-pointer"
-                        @click="displayValueHidden(key)"
-                      >
-                        Show
-                      </b-button>
-                      <span
-                        :key="`spanEntryValue:${value}`"
-                        class="column is-full is-centered p-0 has-text-centered break-word"
-                      >
-                        {{ value | shorten(attributesHiddenState[key] ? shortenSize : -1) }}
-                      </span>
-                    </template>
+                    <div class="columns mb-0 is-mobile">
+                      <div class="column is-9">
+                        <span
+                          :key="`spanEntryValue:${value}`"
+                          class="column is-full is-centered p-0 has-text-centered break-word"
+                        >
+                          {{ value | shorten(attributesHiddenState[key] ? shortenSize : -1) }}
+                        </span>
+                      </div>
+                      <div class="column is-3 p-0 is-flex is-justify-content-center">
+                        <b-button
+                          v-if="!!value && value.length > shortenSize"
+                          size="is-small"
+                          :icon-left="!!attributesHiddenState[key] ? 'eye-slash' : 'eye'"
+                          class="is-cursor-pointer"
+                          @click="displayValueHidden(key)"
+                        >
+                          {{ $t("common.view") }}
+                        </b-button>
+                      </div>
+                    </div>
                   </div>
                 </template>
               </div>
@@ -78,6 +82,10 @@
 import { truncate } from "../../../../common/helpers";
 import { ILdapAttributes, ILdapEntry } from "../../interfaces/entry";
 
+interface ILdapAttributesHiddenState {
+  [attribute: string]: boolean;
+}
+
 export default {
   name: "AppLdapEntry",
   filters: {
@@ -93,9 +101,9 @@ export default {
   },
   data() {
     return {
-      shortenSize: 20,
+      shortenSize: 15,
       attributes: null as ILdapAttributes,
-      attributesHiddenState: {} as ILdapAttributes,
+      attributesHiddenState: {} as ILdapAttributesHiddenState,
     };
   },
   async created() {

--- a/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
+++ b/app/assets/vue/modules/ldap/components/AppLdapEntry/AppLdapEntry.vue
@@ -141,12 +141,8 @@ export default {
 
       return title;
     },
-    displayShowButton(key: string): boolean {
-      if (key.length > this.shortenSize) {
-        return true;
-      } else {
-        return false;
-      }
+    displayShowButton(value: string): boolean {
+      return value.length > this.shortenSize;
     },
     displayValueHidden(key: string): void {
       this.attributesHiddenState[key] = !this.attributesHiddenState[key]; 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in? By default, you should always merge to the develop branch.
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Contribution Guide => https://github.com/Monogramm/ldap-one-for-all/blob/main/CONTRIBUTING.md

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

On the home page the large values go over the container

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

If one of the LDAP user value exceed a certain size without being separated by a space it's overflows.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
